### PR TITLE
The kitchen sink english page does not provide a default image therefore gets the plain old default image in the content tile

### DIFF
--- a/content/src/main/content/jcr_root/content/phonegap/kitchen-sink/en/.content.xml
+++ b/content/src/main/content/jcr_root/content/phonegap/kitchen-sink/en/.content.xml
@@ -10,6 +10,12 @@
         sling:resourceType="brucelefebvre/kitchen-sink/components/splash-page"
         pge-type="[app-content]"
         phonegap-exportTemplate="/content/phonegap/kitchen-sink/en/jcr:content/pge-app/app-config">
+        <image
+            jcr:lastModified="{Date}2014-09-04T16:49:51.263-04:00"
+            jcr:lastModifiedBy="admin"
+            jcr:primaryType="nt:unstructured"
+            fileReference="/content/dam/brucelefebvre/kitchen-sink/thumbnail.png"
+            imageRotate="0"/>
         <pge-app jcr:primaryType="nt:unstructured">
             <app-config/>
             <app-config-dev/>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/6395150/5727150/e8b00714-9b2e-11e4-8bc9-9318d52e76c9.png)

vs

![image](https://cloud.githubusercontent.com/assets/6395150/5727156/f200222c-9b2e-11e4-9b5f-136dc9232a6f.png)
